### PR TITLE
[PR_17] 악세사리 조회 기능 추가 및 장비 조회 코드 수정

### DIFF
--- a/EctTools/EquipmentDescription.py
+++ b/EctTools/EquipmentDescription.py
@@ -5,3 +5,10 @@ def equipmentDescription(equip_name, equip_grade, quality, quality_color, equip_
         description += '\n' + f'```{elixir_text}```'
         
     return description
+
+def accDescription(equip_name, equip_grade, quality, quality_color, equip_type, acc_tooltip_text):
+    description = f'{equip_type} - :{quality_color}_square: **[{quality}] [{equip_grade}] {equip_name}**'
+    
+    description += '\n' + f'```{acc_tooltip_text}```'
+    
+    return description

--- a/EctTools/__init__.py
+++ b/EctTools/__init__.py
@@ -1,3 +1,3 @@
 from .ProfileDescription import profileDescription
-from .EquipmentDescription import equipmentDescription
+from .EquipmentDescription import *
 from .NowTimeConverter import toNowTime

--- a/SearchTools/CharInfoSearch.py
+++ b/SearchTools/CharInfoSearch.py
@@ -124,9 +124,12 @@ class CharInfoSearch(InfoBaseLine):
         # 장비 / 악세 별 json 결과 분류
         eqip_class = []
         acc_class = []
+        ect_class = []
+        
         
         eqip_list = ['무기', '투구', '상의', '하의', '장갑', '어깨']
-        acc_list = ['목걸이', '귀걸이', '반지', '어빌리티 스톤', '팔찌']
+        acc_list = ['목걸이', '귀걸이', '반지']
+        ect_list = ['어빌리티 스톤', '팔찌']
         
         for data in json_res:
             if data["Type"] in eqip_list:
@@ -134,8 +137,10 @@ class CharInfoSearch(InfoBaseLine):
             
             elif data["Type"] in acc_list:
                 acc_class.append(data)
-    
+
+            else:
+                ect_class.append(data)
     
         # 장비 / 악세서리 정보 분리하여 반환
-        return eqip_class, acc_class
+        return eqip_class, acc_class, ect_class
     

--- a/main.py
+++ b/main.py
@@ -35,7 +35,7 @@ async def on_ready():
         print(e)
         
     await bot.change_presence(status=discord.Status.online, 
-                              activity=discord.Game(name='테스트 계정입니다.'))
+                              activity=discord.Game(name='명령어 모음은 /help'))
 
 @bot.tree.command(name='정보', description='캐릭터의 다양한 정보를 알려줍니다.')
 @app_commands.describe(char_name = '닉네임')
@@ -88,13 +88,6 @@ async def char_info(interaction: discord.Interaction, char_name: str) -> None:
     
     await interaction.response.send_message(embed=embed)
     
-# info 커맨드에서 캐릭터 이름이 빠질 시 에러 메시지 반환
-@char_info.error
-async def char_info_error(interaction: discord.Interaction, error):
-    if isinstance(error, commands.MissingRequiredArgument):
-        await interaction.response.send_message('올바른 닉네임 형식을 입력해주세요.')
-
-
 
 @bot.tree.command(name='장비', description='착용한 장비 정보를 알려줍니다.')
 @app_commands.describe(char_name = '닉네임')
@@ -108,9 +101,9 @@ async def equipment_info(interaction: discord.Interaction, char_name: str):
     print(interaction.command.name, toNowTime())
     
     equipment_search = CharInfoSearch(char_name)
-    equipment_info, acc_info = equipment_search.equipmentInfo()
+    equipment_info, _, _ = equipment_search.equipmentInfo()
     
-    if equipment_info == None and acc_info == None:
+    if equipment_info == None:
         await interaction.response.send_message('착용 장비가 없습니다.')
         return
     
@@ -119,8 +112,35 @@ async def equipment_info(interaction: discord.Interaction, char_name: str):
     
     # 제너레이터에서 값 꺼내오기
     for equip_iter in equipmentExtract(equipment_info):
-        description = equipmentDescription(*equip_iter)
+        description = equipmentDescription(**equip_iter)
 
+        embed.add_field(name='', value=description, inline=False)
+    
+    await interaction.response.send_message(embed=embed)
+    
+@bot.tree.command(name='악세', description='착용한 악세서리 정보를 알려줍니다.')
+@app_commands.describe(char_name = '닉네임')
+async def accessory_info(interaction: discord.Interaction, char_name: str):
+    """
+    char_name : 캐릭터 이름
+    
+    return:
+    캐릭터가 착용하는 장비 상세 사항 임베드 메시지
+    """
+    
+    acc_search = CharInfoSearch(char_name)
+    _, acc_info, _ = acc_search.equipmentInfo()
+
+    if acc_info == None:
+        await interaction.response.send_message('착용 악세서리가 없습니다.')
+        return
+
+    embed = discord.Embed(title='')
+    embed.set_author(name=f'착용 악세서리 - {char_name}', icon_url='https://cdn-lostark.game.onstove.com/EFUI_IconAtlas/Acc/Acc_212.png')
+    
+    for acc_iter in accExtract(acc_info):
+        description = accDescription(**acc_iter)
+        
         embed.add_field(name='', value=description, inline=False)
     
     await interaction.response.send_message(embed=embed)


### PR DESCRIPTION
### Issue
1. 악세사리 조회 기능 추가
2. 장비 조회 클래스 코드 수정

### PR 내용
- API의 장비 조회 엔드포인트를 통해 장착 악세사리 조회 기능 추가함
   - 품질 정보, 아이템 이름 및 등급, 스탯 및 각인 정보 출력 

- 기존 장비 조회 클래스에서 장비, 악세서리 2개로 분류하는 로직 세분화
   - 장비, 악세서리, 어빌리티 스톤/팔찌 3개로 분류

### To-do List
- 어빌리티 스톤 및 팔찌 조회 정보 추가할 것
